### PR TITLE
Adding ability to write to named pipe when it exists instead of print to stdout

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = com.newrelic.opentracing
-version = 2.1.0
+version = 2.1.1

--- a/src/main/java/com/newrelic/opentracing/DataCollection.java
+++ b/src/main/java/com/newrelic/opentracing/DataCollection.java
@@ -75,7 +75,7 @@ class DataCollection {
             try {
                 nrTelemetryPipe.writeToPipe(JSONArray.toJSONString(payload));
                 return;
-            } catch (IOException e){
+            } catch (IOException e) {
             }
         }
 

--- a/src/main/java/com/newrelic/opentracing/pipe/NrTelemetryPipe.java
+++ b/src/main/java/com/newrelic/opentracing/pipe/NrTelemetryPipe.java
@@ -17,7 +17,7 @@ public class NrTelemetryPipe {
     }
 
     public void writeToPipe(String payload) throws IOException {
-        try (BufferedWriter pipe = new BufferedWriter(new FileWriter(namedPipePath, false))){
+        try (BufferedWriter pipe = new BufferedWriter(new FileWriter(namedPipePath, false))) {
             pipe.write(payload);
         }
     }

--- a/src/main/java/com/newrelic/opentracing/pipe/NrTelemetryPipe.java
+++ b/src/main/java/com/newrelic/opentracing/pipe/NrTelemetryPipe.java
@@ -1,0 +1,24 @@
+package com.newrelic.opentracing.pipe;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class NrTelemetryPipe {
+    private final File namedPipePath;
+
+    public NrTelemetryPipe(File namedPipePath) {
+        this.namedPipePath = namedPipePath;
+    }
+
+    public boolean namedPipeExists() {
+        return namedPipePath.exists();
+    }
+
+    public void writeToPipe(String payload) throws IOException {
+        try (BufferedWriter pipe = new BufferedWriter(new FileWriter(namedPipePath, false))){
+            pipe.write(payload);
+        }
+    }
+}

--- a/src/test/java/com/newrelic/opentracing/PipeTest.java
+++ b/src/test/java/com/newrelic/opentracing/PipeTest.java
@@ -1,0 +1,51 @@
+package com.newrelic.opentracing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.newrelic.opentracing.pipe.NrTelemetryPipe;
+
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class PipeTest {
+
+    File testPayloadPipe = new File("/tmp/newrelic-telemetry-test");
+
+    @BeforeEach
+    void createPipe() throws IOException {
+        testPayloadPipe.getParentFile().mkdir();
+        testPayloadPipe.createNewFile();
+    }
+
+    @Test
+    void testWrite() throws IOException {
+        NrTelemetryPipe nrTelemetryPipe = new NrTelemetryPipe(testPayloadPipe);
+        String payload = "I am a lambda payload";
+        try {
+            nrTelemetryPipe.writeToPipe(payload);
+        } catch (IOException e){
+        }
+
+        BufferedReader br = new BufferedReader(new FileReader(testPayloadPipe));
+        assertEquals(true, nrTelemetryPipe.namedPipeExists());
+        assertEquals(true, br.readLine().equals(payload));
+    }
+
+    @AfterEach
+    void deletePipe() {
+        File[] listFiles = testPayloadPipe.getParentFile().listFiles();
+        for(File file : listFiles){
+            file.delete();
+        }
+        testPayloadPipe.getParentFile().delete();
+    }
+}

--- a/src/test/java/com/newrelic/opentracing/PipeTest.java
+++ b/src/test/java/com/newrelic/opentracing/PipeTest.java
@@ -1,9 +1,8 @@
 package com.newrelic.opentracing;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.newrelic.opentracing.pipe.NrTelemetryPipe;
-
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -32,18 +31,18 @@ public class PipeTest {
         String payload = "I am a lambda payload";
         try {
             nrTelemetryPipe.writeToPipe(payload);
-        } catch (IOException e){
+        } catch (IOException e) {
         }
 
         BufferedReader br = new BufferedReader(new FileReader(testPayloadPipe));
-        assertEquals(true, nrTelemetryPipe.namedPipeExists());
-        assertEquals(true, br.readLine().equals(payload));
+        assertTrue(nrTelemetryPipe.namedPipeExists());
+        assertTrue(br.readLine().equals(payload));
     }
 
     @AfterEach
     void deletePipe() {
         File[] listFiles = testPayloadPipe.getParentFile().listFiles();
-        for(File file : listFiles){
+        for (File file : listFiles) {
             file.delete();
         }
         testPayloadPipe.getParentFile().delete();


### PR DESCRIPTION
Serverless telemetry is normally sent to stdout. This is an alternate
path designed for use with an externally managed named pipe at a
fixed location.