### PR TITLE
Route some tags to agent attributes

### DIFF
--- a/examples/distributed-tracing-example/DTCalleeFunction/build.gradle
+++ b/examples/distributed-tracing-example/DTCalleeFunction/build.gradle
@@ -15,7 +15,7 @@ java {
 dependencies {
     // New Relic AWS Lambda OpenTracing instrumentation
     implementation('com.newrelic.opentracing:java-aws-lambda:2.1.0')
-    implementation('com.newrelic.opentracing:newrelic-java-lambda:2.1.1')
+    implementation('com.newrelic.opentracing:newrelic-java-lambda:2.1.2')
 
     // OpenTracing
     implementation('io.opentracing:opentracing-util:0.33.0')

--- a/examples/distributed-tracing-example/DTCallerFunction/build.gradle
+++ b/examples/distributed-tracing-example/DTCallerFunction/build.gradle
@@ -15,7 +15,7 @@ java {
 dependencies {
     // New Relic AWS Lambda OpenTracing instrumentation
     implementation('com.newrelic.opentracing:java-aws-lambda:2.1.0')
-    implementation('com.newrelic.opentracing:newrelic-java-lambda:2.1.1')
+    implementation('com.newrelic.opentracing:newrelic-java-lambda:2.1.2')
 
     // OpenTracing
     implementation('io.opentracing:opentracing-util:0.33.0')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = com.newrelic.opentracing
-version = 2.1.1
+version = 2.1.2

--- a/src/main/java/com/newrelic/opentracing/events/TransactionEvent.java
+++ b/src/main/java/com/newrelic/opentracing/events/TransactionEvent.java
@@ -59,7 +59,7 @@ public class TransactionEvent extends Event {
             }
         }
 
-        for(Map.Entry<String, Object> tag : span.getTags().entrySet()) {
+        for (Map.Entry<String, Object> tag : span.getTags().entrySet()) {
             if (AGENT_ATTRIBUTE_KEYS.contains(tag.getKey())) {
                 agentAttributes.put(tag.getKey(), tag.getValue());
             } else {

--- a/src/main/java/com/newrelic/opentracing/events/TransactionEvent.java
+++ b/src/main/java/com/newrelic/opentracing/events/TransactionEvent.java
@@ -12,13 +12,25 @@ import com.newrelic.opentracing.dt.DistributedTracing;
 import com.newrelic.opentracing.state.DistributedTracingState;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class TransactionEvent extends Event {
 
     private final Map<String, Object> intrinsics = new HashMap<>();
     private final Map<String, Object> userAttributes = new HashMap<>();
     private final Map<String, Object> agentAttributes = new HashMap<>();
+
+    private static final Set<String> AGENT_ATTRIBUTE_KEYS;
+    static {
+        AGENT_ATTRIBUTE_KEYS = new HashSet<>();
+        AGENT_ATTRIBUTE_KEYS.add("aws.lambda.arn");
+        AGENT_ATTRIBUTE_KEYS.add("aws.lambda.coldStart");
+        AGENT_ATTRIBUTE_KEYS.add("aws.lambda.eventSource.arn");
+        AGENT_ATTRIBUTE_KEYS.add("aws.lambda.eventSource.eventType");
+        AGENT_ATTRIBUTE_KEYS.add("aws.requestId");
+    }
 
     public TransactionEvent(LambdaSpan span) {
         intrinsics.put("type", "Transaction");
@@ -43,13 +55,19 @@ public class TransactionEvent extends Event {
             }
 
             if (context.getTransactionState().hasError()) {
-                intrinsics.put("error", true);
+                agentAttributes.put("error", true);
             }
         }
 
-        userAttributes.putAll(span.getTags());
-        userAttributes.remove("http.status_code");
+        for(Map.Entry<String, Object> tag : span.getTags().entrySet()) {
+            if (AGENT_ATTRIBUTE_KEYS.contains(tag.getKey())) {
+                agentAttributes.put(tag.getKey(), tag.getValue());
+            } else {
+                userAttributes.put(tag.getKey(), tag.getValue());
+            }
+        }
 
+        userAttributes.remove("http.status_code");
         String status = parseStatusCode(span.getTag("http.status_code"));
         if (status != null && !status.isEmpty()) {
             agentAttributes.put("response.status", status);


### PR DESCRIPTION
The Lambda ingest distingushes between agent and user attributes in
places. Notably, requestId is expected in the agent attributes, and
we display user attributes differently in the user interface.