### PR TITLE
Version bumps for 2.2.1, and a test fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The example below shows how to add them as dependencies in your `build.gradle` f
 
 ```groovy
 dependencies {
-    implementation("com.newrelic.opentracing:newrelic-java-lambda:2.2.0")
+    implementation("com.newrelic.opentracing:newrelic-java-lambda:2.2.1")
     implementation("com.newrelic.opentracing:java-aws-lambda:2.1.0")
 }
 ```
@@ -31,7 +31,7 @@ dependencies {
 The New Relic Lambda Tracer and SDK supports version 0.33.0 of OpenTracing as detailed below: 
 
 * OpenTracing `0.33.0`:
-  * Lambda Tracer: [com.newrelic.opentracing:newrelic-java-lambda:2.2.0](https://search.maven.org/artifact/com.
+  * Lambda Tracer: [com.newrelic.opentracing:newrelic-java-lambda:2.2.1](https://search.maven.org/artifact/com.
     newrelic.opentracing/newrelic-java-lambda)
   * Lambda SDK: [com.newrelic.opentracing:java-aws-lambda:2.1.0](https://search.maven.org/artifact/com.newrelic.opentracing/java-aws-lambda) 
 

--- a/examples/distributed-tracing-example/DTCalleeFunction/build.gradle
+++ b/examples/distributed-tracing-example/DTCalleeFunction/build.gradle
@@ -15,7 +15,7 @@ java {
 dependencies {
     // New Relic AWS Lambda OpenTracing instrumentation
     implementation('com.newrelic.opentracing:java-aws-lambda:2.1.0')
-    implementation('com.newrelic.opentracing:newrelic-java-lambda:2.2.0')
+    implementation('com.newrelic.opentracing:newrelic-java-lambda:2.2.1')
 
     // OpenTracing
     implementation('io.opentracing:opentracing-util:0.33.0')

--- a/examples/distributed-tracing-example/DTCallerFunction/build.gradle
+++ b/examples/distributed-tracing-example/DTCallerFunction/build.gradle
@@ -15,7 +15,7 @@ java {
 dependencies {
     // New Relic AWS Lambda OpenTracing instrumentation
     implementation('com.newrelic.opentracing:java-aws-lambda:2.1.0')
-    implementation('com.newrelic.opentracing:newrelic-java-lambda:2.2.0')
+    implementation('com.newrelic.opentracing:newrelic-java-lambda:2.2.1')
 
     // OpenTracing
     implementation('io.opentracing:opentracing-util:0.33.0')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = com.newrelic.opentracing
-version = 2.2.1
+version = 2.2.2


### PR DESCRIPTION
PipeTest was irresponsibly deleting everything in /tmp
When that failed, it sometimes failed to delete the fake pipe.