### PR TITLE
Preventing NPE when priority in DT payload is null

### DIFF
--- a/src/main/java/com/newrelic/opentracing/LambdaSpanBuilder.java
+++ b/src/main/java/com/newrelic/opentracing/LambdaSpanBuilder.java
@@ -122,10 +122,7 @@ public class LambdaSpanBuilder implements Tracer.SpanBuilder {
             // Our parent context is extracted from a cross-process trace context. New root span.
             final LambdaPayloadContext payloadContext = (LambdaPayloadContext) parentSpanContext;
             final DistributedTracePayloadImpl dtPayload = payloadContext.getPayload();
-            final PrioritySamplingState prioritySamplingState = new PrioritySamplingState(
-                    dtPayload.getPriority(),
-                    dtPayload.isSampled()
-            );
+            final PrioritySamplingState prioritySamplingState = PrioritySamplingState.create(dtPayload);
 
             final DistributedTracingState distributedTracingState = new DistributedTracingState(payloadContext);
             TransactionState transactionState = new TransactionState();

--- a/src/main/java/com/newrelic/opentracing/state/PrioritySamplingState.java
+++ b/src/main/java/com/newrelic/opentracing/state/PrioritySamplingState.java
@@ -5,6 +5,7 @@
 
 package com.newrelic.opentracing.state;
 
+import com.newrelic.opentracing.dt.DistributedTracePayloadImpl;
 import com.newrelic.opentracing.util.DistributedTraceUtil;
 
 public class PrioritySamplingState {
@@ -14,6 +15,14 @@ public class PrioritySamplingState {
     public static PrioritySamplingState setSampledAndGeneratePriority(boolean computeSampled) {
         final float priority = DistributedTraceUtil.nextTruncatedFloat() + (computeSampled ? 1.0f : 0.0f);
         return new PrioritySamplingState(priority, computeSampled);
+    }
+
+    public static PrioritySamplingState create(DistributedTracePayloadImpl dtPayload) {
+        if (dtPayload.getPriority() == null) {
+            return setSampledAndGeneratePriority(dtPayload.isSampled());
+        } else {
+            return new PrioritySamplingState(dtPayload.getPriority(), dtPayload.isSampled());
+        }
     }
 
     public PrioritySamplingState(float priority, boolean sampled) {


### PR DESCRIPTION
Example of faulty payload:
```
DistributedTracePayloadImpl{
  timestamp=1708312234953,
  parentType='Browser',
  accountId='2938894',
  trustKey='2938894',
  applicationId='1588871890',
  guid='169184cca998b086',
  traceId='a78c8c4423dc5a2bfae0665abe8b4700',
  txnId='null',
  sampled=null,
  priority=null
}
```