### PR TITLE
Exclude junit as a transitive dependency of json-simple

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The example below shows how to add them as dependencies in your `build.gradle` f
 
 ```groovy
 dependencies {
-    implementation("com.newrelic.opentracing:newrelic-java-lambda:2.2.2")
-    implementation("com.newrelic.opentracing:java-aws-lambda:2.1.1")
+    implementation("com.newrelic.opentracing:newrelic-java-lambda:2.2.4")
+    implementation("com.newrelic.opentracing:java-aws-lambda:2.2.0")
 }
 ```
 
@@ -31,9 +31,8 @@ dependencies {
 The New Relic Lambda Tracer and SDK supports version 0.33.0 of OpenTracing as detailed below: 
 
 * OpenTracing `0.33.0`:
-  * Lambda Tracer: [com.newrelic.opentracing:newrelic-java-lambda:2.2.1](https://search.maven.org/artifact/com.
-    newrelic.opentracing/newrelic-java-lambda)
-  * Lambda SDK: [com.newrelic.opentracing:java-aws-lambda:2.1.0](https://search.maven.org/artifact/com.newrelic.opentracing/java-aws-lambda) 
+  * Lambda Tracer: [com.newrelic.opentracing:newrelic-java-lambda:2.2.4](https://search.maven.org/artifact/com.newrelic.opentracing/newrelic-java-lambda)
+  * Lambda SDK: [com.newrelic.opentracing:java-aws-lambda:2.2.0](https://search.maven.org/artifact/com.newrelic.opentracing/java-aws-lambda) 
 
 ## Getting Started
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,9 @@ dependencies {
     implementation("io.opentracing:opentracing-api:0.33.0")
     implementation("io.opentracing:opentracing-util:0.33.0")
     implementation("io.opentracing:opentracing-noop:0.33.0")
-    implementation("com.googlecode.json-simple:json-simple:1.1.1")
+    implementation("com.googlecode.json-simple:json-simple:1.1.1") {
+        exclude group: 'junit'
+    }
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.2")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = com.newrelic.opentracing
-version = 2.3.0
+version = 2.2.4


### PR DESCRIPTION
Related to https://github.com/newrelic/newrelic-lambda-tracer-java/issues/46