### PR TITLE
Add fixes to illegalArgException to adaptive sampling

### DIFF
--- a/src/main/java/com/newrelic/opentracing/AdaptiveSampling.java
+++ b/src/main/java/com/newrelic/opentracing/AdaptiveSampling.java
@@ -43,7 +43,8 @@ class AdaptiveSampling {
         if (firstPeriod) {
             sampled = sampledTrueCount.get() < target;
         } else if (sampledTrueCount.get() < target) {
-            sampled = ThreadLocalRandom.current().nextLong(decidedCountLast.get()) < target;
+            final long count = decidedCountLast.get();
+            sampled = count == 0 || ThreadLocalRandom.current().nextLong(count) < target;
         } else {
             final double expTarget = Math.pow(target, (target * 1.0f / sampledTrueCount.get())) - Math.sqrt(target);
             sampled = ThreadLocalRandom.current().nextLong(decidedCount.get()) < expTarget;


### PR DESCRIPTION
This was based on a solution suggested by a customer. This fixes the adaptive sampling issue where an IllegalArgException is thrown in high throughput scenarios. I tested the repro and it is working as expected.  I was debating other solutions such as more strict synchronization but due to performance issues that may arise, the customer solution works best with dealing with the race condition that caused it. 

## Github Issue
https://github.com/newrelic/newrelic-lambda-tracer-java/issues/50